### PR TITLE
Support Latest Version of `aws-sdk-core`

### DIFF
--- a/aws-google.gemspec
+++ b/aws-google.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk-core', '~> 3'
+  spec.add_dependency 'aws-sdk-core', '~> 3.130'
   spec.add_dependency 'google-api-client', '~> 0.23'
   spec.add_dependency 'launchy', '~> 2'
 

--- a/lib/aws/google/cached_credentials.rb
+++ b/lib/aws/google/cached_credentials.rb
@@ -23,9 +23,9 @@ module Aws
       end
 
       def refresh_if_near_expiration
-        if near_expiration?
+        if near_expiration?(SYNC_EXPIRATION_LENGTH)
           @mutex.synchronize do
-            if near_expiration?
+            if near_expiration?(SYNC_EXPIRATION_LENGTH)
               refresh
               write_credentials
             end


### PR DESCRIPTION
Specifically, version 3.130 changed the method signature of the `near_expiration?` method used internally to refresh credentials, so we need to update our own use of that method in response:

```
 11) Error:
Aws::Google::configured::no shared config#test_0001_creates client credentials from Google config:
ArgumentError: wrong number of arguments (given 0, expected 1)
    /home/elijah/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core/refreshing_credentials.rb:86:in `near_expiration?'
    /home/elijah/projects/work/aws-google/lib/aws/google/cached_credentials.rb:26:in `refresh_if_near_expiration'
    /home/elijah/projects/work/aws-google/lib/aws/google/cached_credentials.rb:22:in `initialize'
    /home/elijah/projects/work/aws-google/lib/aws/google.rb:63:in `initialize'
    /home/elijah/projects/work/aws-google/lib/aws/google/credential_provider.rb:35:in `new'
    /home/elijah/projects/work/aws-google/lib/aws/google/credential_provider.rb:35:in `google_credentials_from_config'
    /home/elijah/projects/work/aws-google/lib/aws/google/credential_provider.rb:15:in `google_credentials'
    ...
```

### Links

- https://github.com/aws/aws-sdk-ruby/pull/2642
- [`aws-sdk-core` changelog](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-core/CHANGELOG.md#31300-2022-03-11)