### PR TITLE
Switch to new `google-apis-core` gem

### DIFF
--- a/aws-google.gemspec
+++ b/aws-google.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-sdk-core', '~> 3.130'
-  spec.add_dependency 'google-api-client', '~> 0.23'
+  spec.add_dependency 'google-apis-core'
   spec.add_dependency 'launchy', '~> 2'
 
   spec.add_development_dependency 'activesupport', '~> 5'

--- a/lib/aws/google/version.rb
+++ b/lib/aws/google/version.rb
@@ -1,5 +1,5 @@
 module Aws
   class Google
-    VERSION = '0.1.8'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end


### PR DESCRIPTION
As recommended by [the documentation](https://github.com/googleapis/google-api-ruby-client/blob/main/google-api-client/OVERVIEW.md#are-the-service-specific-gems-drop-in-compatible) now that [the `google-api-client` gem is deprecated](https://github.com/googleapis/google-api-ruby-client/blob/main/google-api-client/CHANGELOG.md#0530-2021-01-18).

Currently, we are only using this dependency in this gem to get access to some `Google::Auth` and `Google::APIClient` functionality, both of which are provided by the new new `google-apis-core` gem: https://github.com/code-dot-org/aws-google/blob/180e1a3cc6bcf61c07c1dbe001caaeff3d9dbae2/lib/aws/google.rb#L7-L8 We do not in this gem need any of the new service-specific gems provided.

## Testing Story

Tested locally with `bundle exec rake test`:
```
Run options: --seed 14585

# Running:

............

Finished in 0.179552s, 66.8330 runs/s, 211.6377 assertions/s.

12 runs, 38 assertions, 0 failures, 0 errors, 0 skips
```

## Deployment Strategy

As per [our documentation](https://github.com/code-dot-org/aws-google/blob/main/README.md#development), after merging this PR I will manually execute `bundle exec rake release` to update RubyGems