### PR TITLE
Support 'auth when you only have CLI' once again

### DIFF
--- a/lib/aws/google/version.rb
+++ b/lib/aws/google/version.rb
@@ -1,5 +1,5 @@
 module Aws
   class Google
-    VERSION = '0.2.0'.freeze
+    VERSION = '0.2.1'.freeze
   end
 end


### PR DESCRIPTION
- We used to have the ability to auth with Google OAuth "out of band" from CLI-only setups like remote ssh or docker containers. ood=>out of band=>generated url can be opened on another computer's browser=>if you only have CLI you need this). No special HTTPS server running on same localhost as the web browser was required.
- Google sunset "oob" support last year (reason: used in phishing scams): https://developers.google.com/identity/protocols/oauth2/resources/oob-migration
- The closest we can come (intentionally on GOOGs security part) requires adding an additional step: a port forward between the desktop computer running Chrome and the server/container running the aws-google instance. This is easily setup in docker-compose or skaffold+k8s situations, but its harder to setup if roll your own (you could use ssh port forwarding).

The UX is basically the same for the end user, but the **caller** of aws-google (outside this library's black box) will have to solve the problem of making the cli-only aws-google server available on the browser desktop computer).