### PR TITLE
Roll back google-apis-core for code-dot-org compatibility

### DIFF
--- a/aws-google.gemspec
+++ b/aws-google.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-sdk-core', '~> 3.211.0'
-  spec.add_dependency 'google-apis-core', '~> 0.15.1'
+  spec.add_dependency 'google-apis-core', '~> 0.11.3' # Newest version compatible with code-dot-org's google_drive>googleauth dependency
   spec.add_dependency 'launchy', '~> 3.0.1'
 
   spec.add_development_dependency 'activesupport', '~> 6.1.7.8'

--- a/lib/aws/google/version.rb
+++ b/lib/aws/google/version.rb
@@ -1,5 +1,5 @@
 module Aws
   class Google
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.2'.freeze
   end
 end


### PR DESCRIPTION
As part of the 0.2.1 upgrade (#7), I also updated and pinned `google-apis-core` to the latest version, 0.15.1. This has a dependency of `googleauth` 1.9. However, over in the code-dot-org repository where we use this gem, we also use the old `google_drive` gem which requires `googleauth < 1.0`

This PR creates version 0.2.2 and rolls google-apis-core back to 0.11.3, the most recent version compatible with `googleauth < 1.0`