### PR TITLE
Remove out of band fallback

### DIFF
--- a/lib/aws/google.rb
+++ b/lib/aws/google.rb
@@ -108,7 +108,7 @@ module Aws
     end
 
     def get_oauth_code(client, options)
-      raise 'fallback' unless @port && !@port.zero?
+      raise ArgumentError.new('Missing port for local oauth server') unless @port && !@port.zero?
 
       require 'launchy'
       require 'webrick'
@@ -135,20 +135,17 @@ module Aws
           end
         end
         while server_thread.alive?
-          raise 'fallback' if !launchy.alive? && !launchy.value.success?
+          unless launchy.alive? && launchy.value.success?
+            server.shutdown
+            raise RuntimeError.new('Failed to launch browser with Launchy')
+          end
 
           sleep 0.1
         end
       end
-      code || raise('fallback')
-    rescue StandardError
+      code || raise('Local Google Oauth failed to get code')
+    ensure
       trap('INT', 'DEFAULT')
-      # Fallback to out-of-band authentication if browser launch failed.
-      client.redirect_uri = 'oob'
-      return ENV['OAUTH_CODE'] if ENV['OAUTH_CODE']
-
-      raise RuntimeError, 'Open the following URL in a browser to get a code,' \
-             "export to $OAUTH_CODE and rerun:\n#{client.authorization_uri(options)}", []
     end
 
     def refresh


### PR DESCRIPTION
The out of band Oauth method [has been blocked by Google since Jan 1, 2023](https://developers.google.com/identity/protocols/oauth2/resources/oob-migration). 

<img width="1072" alt="Screenshot 2025-05-08 at 11 50 25 AM" src="https://github.com/user-attachments/assets/9fae0da5-e786-4899-8fbb-08691fdd51f1" />

This PR removes the fallback to out of band authentication and the message instructing the user to export an oauth code environment variable, since it no longer works.